### PR TITLE
Fix link to capabilities in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ analyzer, with an example call path for each one demonstrating that capability.
 
 ## List of capabilities
 
-See [capabilities documentation](docs/capabilities.md) for a list of the capabilities the tool reports.
+See [capabilities documentation](capabilities.md) for a list of the capabilities the tool reports.
 
 ## Interpreting capability reports
 


### PR DESCRIPTION
When viewing in github's source view, the link from README.md to capabilities documentation takes you to https://github.com/google/capslock/blob/main/docs/docs/capabilities.md which does not exist.