### PR TITLE
Bring-your-own capability mappings

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -27,10 +27,11 @@ import (
 // appropriate capability.
 // If excludedUnanalyzed is true, the UNANALYZED capability is never returned.
 func GetClassifier(excludeUnanalyzed bool) *interesting.Classifier {
+	classifier := interesting.DefaultClassifier()
 	if excludeUnanalyzed {
-		return interesting.DefaultClassifierExcludingUnanalyzed()
+		return interesting.ClassifierExcludingUnanalyzed(classifier)
 	}
-	return interesting.DefaultClassifier()
+	return classifier
 }
 
 // GetCapabilityInfo analyzes the packages in pkgs.  For each function in those

--- a/interesting/interesting.go
+++ b/interesting/interesting.go
@@ -152,7 +152,7 @@ func mergeCapabilityMap(dst, s1, s2 map[string]cpb.Capability) {
 
 // LoadClassifier returns a capability classifier loaded from the specified
 // io.Reader. The filename argument is used only for providing context to
-// error messages. The classifier will also include the default Caplock
+// error messages. The classifier will also include the default Capslock
 // classifications unless the excludeBuiltin is set.
 //
 // Refer to the interesting/interesting.cm file in the source code for an

--- a/interesting/interesting.go
+++ b/interesting/interesting.go
@@ -153,7 +153,7 @@ func mergeCapabilityMap(dst, s1, s2 map[string]cpb.Capability) {
 // LoadClassifier returns a capability classifier loaded from the specified
 // io.Reader. The filename argument is used only for providing context to
 // error messages. The classifier will also include the default Capslock
-// classifications unless the excludeBuiltin is set.
+// classifications unless the excludeBuiltin argument is set.
 //
 // Refer to the interesting/interesting.cm file in the source code for an
 // example of the capability map format. Classifications loaded from a

--- a/interesting/interesting_test.go
+++ b/interesting/interesting_test.go
@@ -7,10 +7,25 @@
 package interesting
 
 import (
+	"strings"
 	"testing"
 
 	cpb "github.com/google/capslock/proto"
 )
+
+const (
+	userCapabilityMap = `
+# Override existing package capability
+package runtime CAPABILITY_NETWORK
+# Specify package capability for a new package
+package example.com/some/package CAPABILITY_OPERATING_SYSTEM
+# Specify package capability for a new function
+func example.com/some/package.Foo CAPABILITY_FILES
+# Override existing function capability
+func fmt.Sprintf CAPABILITY_FILES
+`
+)
+
 
 func TestInteresting(t *testing.T) {
 	classifier := DefaultClassifier()
@@ -34,6 +49,11 @@ func TestInteresting(t *testing.T) {
 			cpb.Capability_CAPABILITY_UNSPECIFIED,
 		},
 		{
+			"example.com/some/package",
+			"example.com/some/package.Foo_Cfunc_GoString",
+			cpb.Capability_CAPABILITY_CGO,
+		},
+		{
 			"os",
 			"os.SomeNewFunctionWithNoFunctionLevelCategoryYet",
 			cpb.Capability_CAPABILITY_OPERATING_SYSTEM,
@@ -47,6 +67,108 @@ func TestInteresting(t *testing.T) {
 			"runtime",
 			"(*runtime.Func).Name",
 			cpb.Capability_CAPABILITY_SAFE,
+		},
+		{
+			"foo",
+			"foo.Something_Cfunc_GoString",
+			cpb.Capability_CAPABILITY_CGO,
+		},
+		{
+			"foo",
+			"foo.Something",
+			cpb.Capability_CAPABILITY_UNSPECIFIED,
+		},
+	} {
+		if got := classifier.FunctionCategory(c.pkg, c.fn); got != c.want {
+			t.Errorf("FunctionCategory(%q, %q): got %q, want %q", c.pkg, c.fn, got, c.want)
+		}
+	}
+}
+
+func TestUserWithBuiltin(t *testing.T) {
+	classifier, err := LoadClassifier(t.Name(), strings.NewReader(userCapabilityMap), false)
+	if err != nil {
+		t.Fatalf("LoadClassifier failed: %v", err)
+	}
+	for _, c := range []struct {
+		pkg, fn string
+		want    cpb.Capability
+	}{
+		{
+			"os",
+			"os.Open",
+			cpb.Capability_CAPABILITY_FILES,
+		},
+		{
+			"os",
+			"os.SomeNewFunctionWithNoFunctionLevelCategoryYet",
+			cpb.Capability_CAPABILITY_OPERATING_SYSTEM,
+		},
+		{
+			"fmt",
+			"fmt.Sprintf",
+			cpb.Capability_CAPABILITY_FILES,
+		},
+		{
+			"example.com/some/package",
+			"example.com/some/package.Foo",
+			cpb.Capability_CAPABILITY_FILES,
+		},
+		{
+			"example.com/some/package",
+			"example.com/some/package.OtherFoo",
+			cpb.Capability_CAPABILITY_OPERATING_SYSTEM,
+		},
+		{
+			"runtime",
+			"runtime.SomeFunction",
+			cpb.Capability_CAPABILITY_NETWORK,
+		},
+	} {
+		if got := classifier.FunctionCategory(c.pkg, c.fn); got != c.want {
+			t.Errorf("FunctionCategory(%q, %q): got %q, want %q", c.pkg, c.fn, got, c.want)
+		}
+	}
+}
+
+func TestUserWithoutBuiltin(t *testing.T) {
+	classifier, err := LoadClassifier(t.Name(), strings.NewReader(userCapabilityMap), true)
+	if err != nil {
+		t.Fatalf("LoadClassifier failed: %v", err)
+	}
+	for _, c := range []struct {
+		pkg, fn string
+		want    cpb.Capability
+	}{
+		{
+			"os",
+			"os.Open",
+			cpb.Capability_CAPABILITY_UNSPECIFIED,
+		},
+		{
+			"os",
+			"os.SomeNewFunctionWithNoFunctionLevelCategoryYet",
+			cpb.Capability_CAPABILITY_UNSPECIFIED,
+		},
+		{
+			"fmt",
+			"fmt.Sprintf",
+			cpb.Capability_CAPABILITY_FILES,
+		},
+		{
+			"example.com/some/package",
+			"example.com/some/package.Foo",
+			cpb.Capability_CAPABILITY_FILES,
+		},
+		{
+			"example.com/some/package",
+			"example.com/some/package.OtherFoo",
+			cpb.Capability_CAPABILITY_OPERATING_SYSTEM,
+		},
+		{
+			"runtime",
+			"runtime.SomeFunction",
+			cpb.Capability_CAPABILITY_NETWORK,
 		},
 	} {
 		if got := classifier.FunctionCategory(c.pkg, c.fn); got != c.want {


### PR DESCRIPTION
This implements the ability to specify a custom capability mapping file, using the same format as `interesting/interesting.cm`. This file may be used to override the default capabilities (e.g. to mark things that the user isn't worried about as `CAPABILITY_SAFE`) but can also be used in place of the the default capability map entirely.

Example session:

```shell
$ # Create a custom capability map.
$ echo "package os/exec CAPABILITY_SAFE" > /tmp/custom.cm
$ ./capslock > /tmp/a
2023/08/25 14:15:42 Loaded package "main"
$ # Use the custom capability map.
$ ./capslock --capability_map=/tmp/custom.cm > /tmp/b 
2023/08/25 14:15:44 Using custom capability map "/tmp/custom.cm"
2023/08/25 14:15:44 Loaded package "main"
$ diff -u /tmp/a /tmp/b
--- /tmp/a	2023-08-25 14:15:44.195909367 +1000
+++ /tmp/b	2023-08-25 14:15:46.359933289 +1000
@@ -8,7 +8,6 @@
 golang.org/x/tools v0.12.0
 google.golang.org/protobuf v1.31.0
 
-CAPABILITY_EXEC: 1 references
 CAPABILITY_FILES: 2 references
 CAPABILITY_OPERATING_SYSTEM: 1 references
 CAPABILITY_READ_SYSTEM_STATE: 2 references
```

I'm not sure whether the `--noisy` flag's sense is backwards (running `capslock` with no arguments on itself does output `CAPABILITY_UNANALYZED`, but I just followed what is already there.