### PR TITLE
Remove if statement whose condition is always false.

### DIFF
--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -33,9 +33,6 @@ var (
 func main() {
 	flag.Parse()
 	packageNames := strings.Split(*packageList, ",")
-	if len(packageNames) == 0 {
-		log.Fatal("No packages provided")
-	}
 	if *disableBuiltin && *customMap == "" {
 		log.Fatal("Error: --disable_builtin only makes sense with a --capability_map file specified")
 	}


### PR DESCRIPTION
The packageNames slice will never be empty.  If the flag -packages is empty, packageNames will contain the empty string, and the package in the current directory will be analyzed.

Fixes #28 