### PR TITLE
Find all methods that use unsafe pointers.

### DIFF
--- a/testing/analyzepackages_test.go
+++ b/testing/analyzepackages_test.go
@@ -160,6 +160,8 @@ func TestExpectedOutput(t *testing.T) {
 		{Fn: []string{`useunsafe.Indirect2`, `useunsafe.init\$1`}},
 		{Fn: []string{`useunsafe.NestedFunctions\$1\$1\$1`}, Cap: `CAPABILITY_UNSAFE_POINTER`},
 		{Fn: []string{`useunsafe.ReturnFunction\$1`}, Cap: `CAPABILITY_UNSAFE_POINTER`},
+		{Fn: []string{`useunsafe.T\).M`}, Cap: "CAPABILITY_UNSAFE_POINTER"},
+		{Fn: []string{`useunsafe.init$`}, Cap: `CAPABILITY_UNSAFE_POINTER`},
 		{Fn: []string{`useunsafe.init\$1`}, Cap: `CAPABILITY_UNSAFE_POINTER`},
 	}
 	for _, path := range expectedPaths {

--- a/testpkgs/useunsafe/useunsafe.go
+++ b/testpkgs/useunsafe/useunsafe.go
@@ -34,6 +34,7 @@ var (
 	I  int
 	U  up = up(&I)
 	IP *int
+	Y  = *(*int)(U)
 	Z  = func() int {
 		return *(*int)(U)
 	}
@@ -82,4 +83,12 @@ func CallNestedFunctions() float32 {
 func Ok() uintptr {
 	var p unsafe.Pointer
 	return (uintptr)(p)
+}
+
+// T is a type with a method that uses an unsafe.Pointer.
+type T struct{}
+
+// M uses an unsafe pointer.
+func (t T) M() int {
+	return *(*int)(U)
 }


### PR DESCRIPTION
Previously we went package-by-package and iterated through (ssa.Package).Members, but this only contains functions, not methods.  Instead we iterate through the result of ssautil.AllFunctions.

Add test cases for a package-level variable whose initialization expression converts an unsafe pointer to *int, and a method which does the same.