### PR TITLE
docs: fix a few typos (Caplock -> Capslock)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To learn more about the capabilities in your dependencies, install Capslock
 go install github.com/google/capslock/cmd/capslock@latest
 ```
 
-You can then invoke Caplock by running `capslock` from the path of the packages you want to analyze.
+You can then invoke Capslock by running `capslock` from the path of the packages you want to analyze.
 
 ## Caveats
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -7,7 +7,7 @@ library calls.
 not stable and are subject to change.** Feedback on the capabilities and
 how they are assigned is very welcome.
 
-The capabilities that Caplock reports are defined in the
+The capabilities that Capslock reports are defined in the
 `src/proto/capability.proto` file, specifically the `Capability`
 enum. The `src/interesting/interesting.go` file contains the mappings
 from library modules and calls to these capabilities.
@@ -29,7 +29,7 @@ on the use of particular types in the code itself, such as
 ## Capabilities
 
 The following section describe the purpose and intent of the
-capabilities that Caplock reports in analyzed code. These descriptions
+capabilities that Capslock reports in analyzed code. These descriptions
 are not meant to be exhaustive.
 
 ### CAPABILITY_UNSPECIFIED

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -107,7 +107,7 @@ reassure ourselves that nothing concerning is present in our dependencies.
 
 There are two types of machine readable outputs produced by Capslock:
 
-*  JSON, by using -output=j or -output=j
+*  JSON, by using -output=j or -output=json
 *  A list of capability types, from -output=m
 
 


### PR DESCRIPTION
Also, fix example use of -output=json flag.