### PR TITLE
analyzer: add determinism for various output modes

### DIFF
--- a/analyzer/scan.go
+++ b/analyzer/scan.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"go/types"
 	"os"
+	"sort"
 	"strings"
 	"text/template"
 
@@ -44,8 +45,13 @@ func RunCapslock(args []string, output string, pkgs []*packages.Package, queried
 		fmt.Println(string(b))
 		return nil
 	} else if output == "m" || output == "machine" {
+		var cs []string
 		cil := GetCapabilityCounts(pkgs, queriedPackages, config)
 		for c := range cil.CapabilityCounts {
+			cs = append(cs, c)
+		}
+		sort.Strings(cs)
+		for _, c := range cs {
 			fmt.Println(c)
 		}
 		return nil


### PR DESCRIPTION
While the choice of call path the tool displays to demonstrate why a function has a particular capability is somewhat arbitrary, it's useful if the choice is consistent across runs so that outputs can be compared more easily.

To achieve this, we add sorts in various places, and improve the existing sorts for graph nodes and edges so there are no spurious ties between items.