### PR TITLE
analyzer: use a single call to packages.Load for all packages

### DIFF
--- a/analyzer/load.go
+++ b/analyzer/load.go
@@ -8,7 +8,6 @@ package analyzer
 
 import (
 	"go/types"
-	"log"
 	"os"
 	"path"
 	"sort"
@@ -59,7 +58,7 @@ func GetQueriedPackages(pkgs []*packages.Package) map[*types.Package]struct{} {
 	return queriedPackages
 }
 
-func LoadPackages(packageNames []string, lcfg LoadConfig) []*packages.Package {
+func LoadPackages(packageNames []string, lcfg LoadConfig) ([]*packages.Package, error) {
 	cfg := &packages.Config{Mode: PackagesLoadModeNeeded}
 	if lcfg.BuildTags != "" {
 		cfg.BuildFlags = []string{"-tags=" + lcfg.BuildTags}
@@ -74,16 +73,7 @@ func LoadPackages(packageNames []string, lcfg LoadConfig) []*packages.Package {
 		}
 		cfg.Env = env
 	}
-	pkgs := []*packages.Package{}
-	for _, p := range packageNames {
-		pkg, err := packages.Load(cfg, p)
-		if err != nil {
-			log.Printf("Error loading packages %v: %v\n", p, err)
-			continue
-		}
-		pkgs = append(pkgs, pkg...)
-	}
-	return pkgs
+	return packages.Load(cfg, packageNames...)
 }
 
 func standardLibraryPackages() map[string]struct{} {

--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -55,12 +55,15 @@ func main() {
 		classifier = analyzer.GetClassifier(*noiseFlag)
 	}
 
-	pkgs := analyzer.LoadPackages(packageNames,
+	pkgs, err := analyzer.LoadPackages(packageNames,
 		analyzer.LoadConfig{
 			BuildTags: *buildTags,
 			GOOS:      *goos,
 			GOARCH:    *goarch,
 		})
+	if err != nil {
+		log.Fatalf("Error loading packages: %v", err)
+	}
 	if len(pkgs) == 0 {
 		log.Fatalf("No packages matching %v", packageNames)
 	}
@@ -71,7 +74,7 @@ func main() {
 			log.Printf("Loaded package %q\n", p.Name)
 		}
 	}
-	err := analyzer.RunCapslock(flag.Args(), *output, pkgs, queriedPackages, classifier)
+	err = analyzer.RunCapslock(flag.Args(), *output, pkgs, queriedPackages, classifier)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This results in all the loaded source being stored in a single token.FileSet.  Without this, we couldn't look up line numbers correctly if there was more than one package pattern specified on the command line.