### PR TITLE
Make Capslock respect custom capability mappings.

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -44,7 +44,7 @@ func TestAnalysis(t *testing.T) {
 		t.Fatalf("packages.Load: %v", err)
 	}
 	queriedPackages := GetQueriedPackages(pkgs)
-	cil := GetCapabilityInfo(pkgs, queriedPackages, interesting.DefaultClassifier())
+	cil := GetCapabilityInfo(pkgs, queriedPackages, interesting.DefaultClassifier(), false)
 	expected := &cpb.CapabilityInfoList{
 		CapabilityInfo: []*cpb.CapabilityInfo{{
 			PackageName: proto.String("testlib"),

--- a/analyzer/compare.go
+++ b/analyzer/compare.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func compare(baselineFilename string, pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, classifier *interesting.Classifier) error {
+func compare(baselineFilename string, pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, classifier *interesting.Classifier, disableBuiltin bool) error {
 	compareData, err := os.ReadFile(baselineFilename)
 	if err != nil {
 		return fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from reading comparison file: %v", programName(), err.Error())
@@ -28,7 +28,7 @@ func compare(baselineFilename string, pkgs []*packages.Package, queriedPackages 
 	if err != nil {
 		return fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from parsing comparison file: %v", programName(), err.Error())
 	}
-	cil := GetCapabilityInfo(pkgs, queriedPackages, classifier)
+	cil := GetCapabilityInfo(pkgs, queriedPackages, classifier, disableBuiltin)
 	diffCapabilityInfoLists(baseline, cil)
 	return nil
 }

--- a/analyzer/graph.go
+++ b/analyzer/graph.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, classifier *interesting.Classifier) error {
+func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, classifier *interesting.Classifier, disableBuiltin bool) error {
 	w := bufio.NewWriterSize(os.Stdout, 1<<20)
 	gb := newGraphBuilder(w, func(v interface{}) string {
 		switch v := v.(type) {
@@ -41,7 +41,7 @@ func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]st
 	capabilityEdge := func(fn *callgraph.Node, c cpb.Capability) {
 		gb.Edge(fn, c)
 	}
-	CapabilityGraph(pkgs, queriedPackages, classifier, callEdge, capabilityEdge)
+	CapabilityGraph(pkgs, queriedPackages, classifier, disableBuiltin, callEdge, capabilityEdge)
 	gb.Done()
 	return w.Flush()
 }

--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -74,7 +74,7 @@ func main() {
 			log.Printf("Loaded package %q\n", p.Name)
 		}
 	}
-	err = analyzer.RunCapslock(flag.Args(), *output, pkgs, queriedPackages, classifier)
+	err = analyzer.RunCapslock(flag.Args(), *output, pkgs, queriedPackages, classifier, *disableBuiltin)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When the disable_builtin flag is set with a custom classifier, default capabilities should not be added.