### PR TITLE
go.mod: depend on latest commit of golang.org/x/tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/fatih/color v1.16.0
 	github.com/google/go-cmp v0.6.0
-	golang.org/x/tools v0.19.0
+	golang.org/x/tools v0.19.1-0.20240311201356-ca94c9663f9a
 	google.golang.org/protobuf v1.33.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,5 +16,7 @@ golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=
 golang.org/x/tools v0.19.0/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
+golang.org/x/tools v0.19.1-0.20240311201356-ca94c9663f9a h1:DvfFvSl+85pd8XNrPZmFPq20GeeEwJUo3cn3fc+xnwQ=
+golang.org/x/tools v0.19.1-0.20240311201356-ca94c9663f9a/go.mod h1:qoJWxmGSIBmAeriMx19ogtrEPrGtDbPK634QFIcLAhc=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=


### PR DESCRIPTION
This picks up some fixes added since the last version tag of x/tools.