### PR TITLE
docs: fix typos

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -21,7 +21,7 @@ functions override this with other capabilities, such as the
 `CAPABILITY_FILES`.
 
 In addition to mapping packages and library calls to
-capabilites, Capslock may also assign capabilities based
+capabilities, Capslock may also assign capabilities based
 on the use of particular types in the code itself, such as
 [unsafe.Pointer](https://pkg.go.dev/unsafe#Pointer) or
 [reflect.Value](https://pkg.go.dev/reflect#Value).

--- a/interesting/interesting.go
+++ b/interesting/interesting.go
@@ -22,7 +22,7 @@ import (
 //go:embed interesting.cm
 var interestingData string
 
-// Type Classifier contains informatation used to map code features to
+// Type Classifier contains information used to map code features to
 // concrete capabilities.
 type Classifier struct {
 	functionCategory   map[string]cpb.Capability


### PR DESCRIPTION
The PR corrects a typo in the documentation and the comment.