### PR TITLE
analyzer: change IncludeCall to take a *callgraph.Edge

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -44,7 +44,7 @@ type Classifier interface {
 	// considered when searching for transitive capabilities.  Usually this should
 	// return true, unless there is some reason to know that the particular call
 	// cannot lead to additional capabilities for a function.
-	IncludeCall(caller string, callee string) bool
+	IncludeCall(edge *callgraph.Edge) bool
 }
 
 // GetClassifier returns a classifier for mapping packages and functions to the
@@ -255,10 +255,8 @@ func searchBackwardsFromCapabilities(nodesByCapability nodesetPerCapability, saf
 	for len(q) > 0 {
 		v := q[0]
 		q = q[1:]
-		calleeName := v.Func.String()
 		for _, edge := range v.In {
-			callerName := edge.Caller.Func.String()
-			if !classifier.IncludeCall(callerName, calleeName) {
+			if !classifier.IncludeCall(edge) {
 				continue
 			}
 			w := edge.Caller
@@ -307,11 +305,9 @@ func searchForwardsFromQueriedFunctions(
 		if _, ok := allNodesWithExplicitCapability[v]; ok {
 			continue
 		}
-		calleeName := v.Func.String()
 		out := make(nodeset)
 		for _, edge := range v.Out {
-			callerName := edge.Caller.Func.String()
-			if !classifier.IncludeCall(callerName, calleeName) {
+			if !classifier.IncludeCall(edge) {
 				continue
 			}
 			w := edge.Callee
@@ -647,10 +643,8 @@ func forEachPath(pkgs []*packages.Package, queriedPackages map[*types.Package]st
 			v := q[0]
 			q = q[1:]
 			var incomingEdges []*callgraph.Edge
-			calleeName := v.Func.String()
 			for _, edge := range v.In {
-				callerName := edge.Caller.Func.String()
-				if config.Classifier.IncludeCall(callerName, calleeName) {
+				if config.Classifier.IncludeCall(edge) {
 					incomingEdges = append(incomingEdges, edge)
 				}
 			}

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -7,13 +7,17 @@
 package analyzer
 
 import (
+	"fmt"
+	"go/types"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/google/capslock/interesting"
 	cpb "github.com/google/capslock/proto"
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/go/analysis/analysistest"
+	"golang.org/x/tools/go/callgraph"
 	"golang.org/x/tools/go/packages"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -23,27 +27,39 @@ var filemap = map[string]string{"testlib/foo.go": `package testlib
 
 import "os"
 
-func Foo() {
-	println(os.Getpid())
-}`}
+func Foo() { println(os.Getpid()) }
+func A() { B(); C() }
+func B() { C() }
+func C() { println(os.IsExist(nil)) }
+`}
 
-func TestAnalysis(t *testing.T) {
+func setup() (pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, cleanup func(), err error) {
 	dir, cleanup, err := analysistest.WriteFiles(filemap)
 	if err != nil {
-		t.Fatalf("analysistest.WriteFiles: %v", err)
+		return nil, nil, cleanup, fmt.Errorf("analysistest.WriteFiles: %w", err)
 	}
-	defer cleanup()
 	env := []string{"GOPATH=" + dir, "GO111MODULE=off", "GOPROXY=off"}
 	cfg := &packages.Config{
 		Mode: PackagesLoadModeNeeded,
 		Dir:  dir,
 		Env:  append(os.Environ(), env...),
 	}
-	pkgs, err := packages.Load(cfg, "testlib")
+	pkgs, err = packages.Load(cfg, "testlib")
 	if err != nil {
-		t.Fatalf("packages.Load: %v", err)
+		return nil, nil, cleanup, fmt.Errorf("packages.Load: %w", err)
 	}
-	queriedPackages := GetQueriedPackages(pkgs)
+	queriedPackages = GetQueriedPackages(pkgs)
+	return pkgs, queriedPackages, cleanup, nil
+}
+
+func TestAnalysis(t *testing.T) {
+	pkgs, queriedPackages, cleanup, err := setup()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
 	cil := GetCapabilityInfo(pkgs, queriedPackages, &Config{
 		Classifier:     interesting.DefaultClassifier(),
 		DisableBuiltin: false,
@@ -72,5 +88,164 @@ func TestAnalysis(t *testing.T) {
 	if diff := cmp.Diff(expected, cil, opts...); diff != "" {
 		t.Errorf("GetCapabilityInfo(%v): got %v, want %v; diff %s",
 			filemap, cil, expected, diff)
+	}
+}
+
+func TestGraph(t *testing.T) {
+	pkgs, queriedPackages, cleanup, err := setup()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	calls := make(map[[2]string]struct{})
+	caps := make(map[string][]cpb.Capability)
+	CapabilityGraph(pkgs, queriedPackages,
+		&Config{
+			Classifier:     interesting.DefaultClassifier(),
+			DisableBuiltin: false,
+		},
+		func(from, to *callgraph.Node) {
+			calls[[2]string{from.Func.String(), to.Func.String()}] = struct{}{}
+		},
+		func(fn *callgraph.Node, c cpb.Capability) {
+			f := fn.Func.String()
+			caps[f] = append(caps[f], c)
+		})
+	expectedCalls := map[[2]string]struct{}{
+		{"testlib.Foo", "os.Getpid"}: {},
+	}
+	expectedCaps := map[string][]cpb.Capability{
+		"os.Getpid": {cpb.Capability_CAPABILITY_READ_SYSTEM_STATE},
+	}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Errorf("CapabilityGraph(%v): got calls %v want %v",
+			filemap, calls, expectedCalls)
+	}
+	if !reflect.DeepEqual(caps, expectedCaps) {
+		t.Errorf("CapabilityGraph(%v): got capabilities %v want %v",
+			filemap, caps, expectedCaps)
+	}
+}
+
+// testClassifier is used for testing that non-default classifiers work
+// correctly.
+type testClassifier struct{}
+
+func (testClassifier) FunctionCategory(pkg string, name string) cpb.Capability {
+	// Only categorize os.IsExist as having a capability.
+	if pkg == "os" && name == "os.IsExist" {
+		return cpb.Capability_CAPABILITY_FILES
+	}
+	return 0
+}
+func (testClassifier) IncludeCall(edge *callgraph.Edge) bool {
+	// Exclude calls from A to C.
+	caller := edge.Caller.Func.String()
+	callee := edge.Callee.Func.String()
+	return !(caller == "testlib.A" && callee == "testlib.C")
+}
+
+func TestAnalysisWithClassifier(t *testing.T) {
+	pkgs, queriedPackages, cleanup, err := setup()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	cil := GetCapabilityInfo(pkgs, queriedPackages, &Config{
+		Classifier:     testClassifier{},
+		DisableBuiltin: true,
+	})
+	expected := &cpb.CapabilityInfoList{
+		CapabilityInfo: []*cpb.CapabilityInfo{{
+			PackageName: proto.String("testlib"),
+			Capability:  cpb.Capability_CAPABILITY_FILES.Enum(),
+			Path: []*cpb.Function{
+				&cpb.Function{Name: proto.String("testlib.A")},
+				&cpb.Function{Name: proto.String("testlib.B")},
+				&cpb.Function{Name: proto.String("testlib.C")},
+				&cpb.Function{Name: proto.String("os.IsExist")},
+			},
+			PackageDir:     proto.String("testlib"),
+			CapabilityType: cpb.CapabilityType_CAPABILITY_TYPE_DIRECT.Enum(),
+		}, {
+			PackageName: proto.String("testlib"),
+			Capability:  cpb.Capability_CAPABILITY_FILES.Enum(),
+			Path: []*cpb.Function{
+				&cpb.Function{Name: proto.String("testlib.B")},
+				&cpb.Function{Name: proto.String("testlib.C")},
+				&cpb.Function{Name: proto.String("os.IsExist")},
+			},
+			PackageDir:     proto.String("testlib"),
+			CapabilityType: cpb.CapabilityType_CAPABILITY_TYPE_DIRECT.Enum(),
+		}, {
+			PackageName: proto.String("testlib"),
+			Capability:  cpb.Capability_CAPABILITY_FILES.Enum(),
+			Path: []*cpb.Function{
+				&cpb.Function{Name: proto.String("testlib.C")},
+				&cpb.Function{Name: proto.String("os.IsExist")},
+			},
+			PackageDir:     proto.String("testlib"),
+			CapabilityType: cpb.CapabilityType_CAPABILITY_TYPE_DIRECT.Enum(),
+		}},
+	}
+	opts := []cmp.Option{
+		protocmp.Transform(),
+		protocmp.SortRepeated(func(a, b *cpb.CapabilityInfo) bool {
+			return a.GetDepPath() < b.GetDepPath()
+		}),
+		protocmp.IgnoreFields(&cpb.CapabilityInfoList{}, "package_info"),
+		protocmp.IgnoreFields(&cpb.CapabilityInfo{}, "dep_path"),
+		protocmp.IgnoreFields(&cpb.Function{}, "site"),
+		protocmp.IgnoreFields(&cpb.Function_Site{}, "filename"),
+		protocmp.IgnoreFields(&cpb.Function_Site{}, "line"),
+		protocmp.IgnoreFields(&cpb.Function_Site{}, "column"),
+	}
+	if diff := cmp.Diff(expected, cil, opts...); diff != "" {
+		t.Errorf("GetCapabilityInfo(%v): got %v, want %v; diff %s",
+			filemap, cil, expected, diff)
+	}
+}
+
+func TestGraphWithClassifier(t *testing.T) {
+	pkgs, queriedPackages, cleanup, err := setup()
+	if cleanup != nil {
+		defer cleanup()
+	}
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	calls := make(map[[2]string]struct{})
+	caps := make(map[string][]cpb.Capability)
+	CapabilityGraph(pkgs, queriedPackages,
+		&Config{
+			Classifier:     testClassifier{},
+			DisableBuiltin: true,
+		},
+		func(from, to *callgraph.Node) {
+			calls[[2]string{from.Func.String(), to.Func.String()}] = struct{}{}
+		},
+		func(fn *callgraph.Node, c cpb.Capability) {
+			f := fn.Func.String()
+			caps[f] = append(caps[f], c)
+		})
+	expectedCalls := map[[2]string]struct{}{
+		{"testlib.A", "testlib.B"}:  {},
+		{"testlib.B", "testlib.C"}:  {},
+		{"testlib.C", "os.IsExist"}: {},
+	}
+	expectedCaps := map[string][]cpb.Capability{
+		"os.IsExist": {cpb.Capability_CAPABILITY_FILES},
+	}
+	if !reflect.DeepEqual(calls, expectedCalls) {
+		t.Errorf("CapabilityGraph(%v): got calls %v want %v",
+			filemap, calls, expectedCalls)
+	}
+	if !reflect.DeepEqual(caps, expectedCaps) {
+		t.Errorf("CapabilityGraph(%v): got capabilities %v want %v",
+			filemap, caps, expectedCaps)
 	}
 }

--- a/interesting/interesting.go
+++ b/interesting/interesting.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	cpb "github.com/google/capslock/proto"
+	"golang.org/x/tools/go/callgraph"
 )
 
 //go:embed interesting.cm
@@ -197,7 +198,9 @@ func LoadClassifier(source string, r io.Reader, excludeBuiltin bool) (*Classifie
 // considered when searching for transitive capabilities.  We return false for
 // some internal calls in the standard library where we know a potential
 // transitive capability does not arise in practice.
-func (c *Classifier) IncludeCall(caller, callee string) bool {
+func (c *Classifier) IncludeCall(edge *callgraph.Edge) bool {
+	caller := edge.Caller.Func.String()
+	callee := edge.Callee.Func.String()
 	_, ok := internalMap.ignoredEdges[[2]string{caller, callee}]
 	return !ok
 }


### PR DESCRIPTION
This is simpler than having each callsite extract the caller and callee.  This fixes one callsite where this was done incorrectly.

Add more tests to analyzer_test.