### PR TITLE
analyzer: some changes to the comparison code

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -22,8 +22,15 @@ import (
 
 // Config holds configuration for the analyzer.
 type Config struct {
-	Classifier     Classifier
+	// Classifier is used to assign capabilities to functions.
+	Classifier Classifier
+	// DisableBuiltin disables some additional source-code analyses that find
+	// more capabilities in functions.
 	DisableBuiltin bool
+	// Granularity can be "package" or "function".  It determines whether
+	// capability sets are examined per-package or per-function when doing
+	// comparisons.
+	Granularity string
 }
 
 // Classifier is an interface for types that help map code features to

--- a/analyzer/compare.go
+++ b/analyzer/compare.go
@@ -11,81 +11,137 @@ import (
 	"go/types"
 	"os"
 	"sort"
+	"text/tabwriter"
 
 	cpb "github.com/google/capslock/proto"
 	"golang.org/x/tools/go/packages"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func compare(baselineFilename string, pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, config *Config) error {
+// granularity determines the kind of comparison done by compare.
+type granularity int8
+
+const (
+	granularityPackage  granularity = iota // compare capabilities per package
+	granularityFunction                    // compare capabilities per function
+)
+
+func granularityFromString(g string) (granularity, error) {
+	switch g {
+	case "package":
+		return granularityPackage, nil
+	case "function":
+		return granularityFunction, nil
+	default:
+		return 0, fmt.Errorf("unknown granularity: %q", g)
+	}
+}
+
+func compare(baselineFilename string, pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, config *Config) (different bool, err error) {
+	g, err := granularityFromString(config.Granularity)
+	if err != nil {
+		return false, err
+	}
 	compareData, err := os.ReadFile(baselineFilename)
 	if err != nil {
-		return fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from reading comparison file: %v", programName(), err.Error())
+		return false, fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from reading comparison file: %v", programName(), err.Error())
 	}
 	baseline := new(cpb.CapabilityInfoList)
 	err = protojson.Unmarshal(compareData, baseline)
 	if err != nil {
-		return fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from parsing comparison file: %v", programName(), err.Error())
+		return false, fmt.Errorf("Comparison file should include output from running `%s -output=j`. Error from parsing comparison file: %v", programName(), err.Error())
 	}
 	cil := GetCapabilityInfo(pkgs, queriedPackages, config)
-	diffCapabilityInfoLists(baseline, cil)
-	return nil
+	return diffCapabilityInfoLists(baseline, cil, g), nil
 }
 
-type capabilitySet map[cpb.Capability]*cpb.CapabilityInfo
-type capabilitiesMap map[string]capabilitySet
+type mapKey struct {
+	key        string
+	capability cpb.Capability
+}
+type capabilitiesMap map[mapKey]*cpb.CapabilityInfo
 
 // populateMap takes a CapabilityInfoList and returns a map from package
-// directory and capability to a pointer to the corresponding entry in the
+// or function and capability to a pointer to the corresponding entry in the
 // input.
-func populateMap(cil *cpb.CapabilityInfoList) capabilitiesMap {
+func populateMap(cil *cpb.CapabilityInfoList, g granularity) capabilitiesMap {
 	m := make(capabilitiesMap)
 	for _, ci := range cil.GetCapabilityInfo() {
-		dir := ci.GetPackageDir()
-		capmap := m[dir]
-		if capmap == nil {
-			capmap = make(capabilitySet)
-			m[dir] = capmap
+		mk := mapKey{capability: ci.GetCapability()}
+		// The calculation of mk.key depends on the desired granularity.
+		switch g {
+		case granularityPackage:
+			mk.key = ci.GetPackageDir()
+			m[mk] = ci
+		case granularityFunction:
+			if len(ci.Path) == 0 {
+				break
+			}
+			mk.key = ci.Path[0].GetName()
+			if mk.key != "" {
+				m[mk] = ci
+			}
 		}
-		capmap[ci.GetCapability()] = ci
 	}
 	return m
 }
 
-func diffCapabilityInfoLists(baseline, current *cpb.CapabilityInfoList) {
-	baselineMap := populateMap(baseline)
-	currentMap := populateMap(current)
-	var packages []string
-	for packageName := range baselineMap {
-		packages = append(packages, packageName)
+func diffCapabilityInfoLists(baseline, current *cpb.CapabilityInfoList, g granularity) (different bool) {
+	baselineMap := populateMap(baseline, g)
+	currentMap := populateMap(current, g)
+	var keys []mapKey
+	for k := range baselineMap {
+		keys = append(keys, k)
 	}
-	for packageName := range currentMap {
-		if _, ok := baselineMap[packageName]; !ok {
-			packages = append(packages, packageName)
+	for k := range currentMap {
+		if _, ok := baselineMap[k]; !ok {
+			keys = append(keys, k)
 		}
 	}
-	sort.Strings(packages)
-	var differenceFound bool
-	for _, packageName := range packages {
-		b := baselineMap[packageName]
-		c := currentMap[packageName]
-		for capability := range c {
-			if _, ok := b[capability]; !ok {
-				differenceFound = true
-				fmt.Printf("Package %s has new capability %s compared to the baseline.\n",
-					packageName, capability)
+	sort.Slice(keys, func(i, j int) bool {
+		if a, b := keys[i].capability, keys[j].capability; a != b {
+			return a < b
+		}
+		return keys[i].key < keys[j].key
+	})
+	for _, key := range keys {
+		ciBaseline, inBaseline := baselineMap[key]
+		ciCurrent, inCurrent := currentMap[key]
+		if !inBaseline && inCurrent {
+			if different {
+				fmt.Println()
 			}
+			different = true
+			fmt.Printf("Package %s has new capability %s compared to the baseline.\n",
+				key.key, key.capability)
+			printCallPath(ciCurrent.Path)
 		}
-		for capability := range b {
-			if _, ok := c[capability]; !ok {
-				differenceFound = true
-				fmt.Printf("Package %s no longer has capability %s which was in the baseline.\n",
-					packageName, capability)
+		if inBaseline && !inCurrent {
+			if different {
+				fmt.Println()
 			}
+			different = true
+			fmt.Printf("Package %s no longer has capability %s which was in the baseline.\n",
+				key.key, key.capability)
+			printCallPath(ciBaseline.Path)
 		}
 	}
-	if differenceFound {
-		os.Exit(1)
+	return different
+}
+
+func printCallPath(fns []*cpb.Function) {
+	tw := tabwriter.NewWriter(
+		os.Stdout, // output
+		10,        // minwidth
+		8,         // tabwidth
+		2,         // padding
+		' ',       // padchar
+		0)         // flags
+	for _, f := range fns {
+		if f.Site != nil {
+			fmt.Fprint(tw, f.Site.GetFilename(), ":", f.Site.GetLine(), ":", f.Site.GetColumn())
+		}
+		fmt.Fprint(tw, "\t", f.GetName(), "\n")
 	}
-	os.Exit(0)
+	tw.Flush()
 }

--- a/analyzer/scan.go
+++ b/analyzer/scan.go
@@ -23,13 +23,28 @@ import (
 //go:embed static/*
 var staticContent embed.FS
 
+// DifferenceFoundError indicates that a comparison was successfully run, and
+// a difference was found.
+type DifferenceFoundError struct{}
+
+func (d DifferenceFoundError) Error() string {
+	return "difference found"
+}
+
 func RunCapslock(args []string, output string, pkgs []*packages.Package, queriedPackages map[*types.Package]struct{},
 	config *Config) error {
 	if output == "compare" {
 		if len(args) != 1 {
 			return fmt.Errorf("Usage: %s -output=compare <filename>; provided %v args", programName(), len(args))
 		}
-		compare(args[0], pkgs, queriedPackages, config)
+		different, err := compare(args[0], pkgs, queriedPackages, config)
+		if err != nil {
+			return err
+		}
+		if different {
+			return DifferenceFoundError{}
+		}
+		return nil
 	} else if len(args) >= 1 {
 		return fmt.Errorf("%s: unknown command", args)
 	}


### PR DESCRIPTION
Change compare to return its result to the caller rather than exiting the program on its own.

Add example stack traces to diff reports.

Add a "granularity" option that determines whether capabilities are compared for each package or each function.

Add some more tests.