### PR TITLE
cmd/capslock: add a flag to limit capabilities in graph output

### DIFF
--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -116,7 +116,8 @@ func TestGraph(t *testing.T) {
 		func(fn *callgraph.Node, c cpb.Capability) {
 			f := fn.Func.String()
 			caps[f] = append(caps[f], c)
-		})
+		},
+		nil)
 	expectedNodes := map[string]struct{}{
 		"testlib.Foo": {},
 		"os.Getpid":   {},
@@ -247,7 +248,8 @@ func TestGraphWithClassifier(t *testing.T) {
 		func(fn *callgraph.Node, c cpb.Capability) {
 			f := fn.Func.String()
 			caps[f] = append(caps[f], c)
-		})
+		},
+		nil)
 	expectedNodes := map[string]struct{}{
 		"testlib.A":  {},
 		"testlib.B":  {},

--- a/analyzer/graph.go
+++ b/analyzer/graph.go
@@ -8,6 +8,7 @@ package analyzer
 
 import (
 	"bufio"
+	"fmt"
 	"go/types"
 	"io"
 	"os"
@@ -19,7 +20,40 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+func parseCapabilitiesList(cs string) (capabilities map[cpb.Capability]struct{}, negated bool, err error) {
+	if len(cs) == 0 {
+		return nil, true, nil
+	}
+	out := make(map[cpb.Capability]struct{})
+	for i, s := range strings.Split(cs, ",") {
+		if len(s) == 0 {
+			return nil, false, fmt.Errorf("empty capability in list: %q", cs)
+		}
+		neg := s[0] == '-'
+		if neg {
+			s = s[1:]
+		}
+		if i > 0 && neg != negated {
+			return nil, false, fmt.Errorf("mix of negated and unnegated capabilities specified: %q", cs)
+		}
+		negated = neg
+		c, ok := cpb.Capability_value[s]
+		if !ok {
+			c, ok = cpb.Capability_value["CAPABILITY_"+s]
+		}
+		if !ok {
+			return nil, false, fmt.Errorf("unknown capability %q", s)
+		}
+		out[cpb.Capability(c)] = struct{}{}
+	}
+	return out, negated, nil
+}
+
 func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]struct{}, config *Config) error {
+	capabilities, negated, err := parseCapabilitiesList(config.Capabilities)
+	if err != nil {
+		return err
+	}
 	w := bufio.NewWriterSize(os.Stdout, 1<<20)
 	gb := newGraphBuilder(w, func(v interface{}) string {
 		switch v := v.(type) {
@@ -40,7 +74,14 @@ func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]st
 	capabilityEdge := func(fn *callgraph.Node, c cpb.Capability) {
 		gb.Edge(fn, c)
 	}
-	CapabilityGraph(pkgs, queriedPackages, config, nil, callEdge, capabilityEdge)
+	var filter func(c cpb.Capability) bool
+	if len(capabilities) != 0 {
+		filter = func(c cpb.Capability) bool {
+			_, ok := capabilities[c]
+			return ok != negated
+		}
+	}
+	CapabilityGraph(pkgs, queriedPackages, config, nil, callEdge, capabilityEdge, filter)
 	gb.Done()
 	return w.Flush()
 }

--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -33,6 +33,7 @@ var (
 	noiseFlag      = flag.Bool("noisy", false, "include output on unanalyzed function calls (can be noisy)")
 	customMap      = flag.String("capability_map", "", "use a custom capability map file")
 	disableBuiltin = flag.Bool("disable_builtin", false, "when using a custom capability map, disable the builtin capability mappings")
+	capabilities   = flag.String("capabilities", "", "if non-empty, a comma-separated list of capabilities to consider for graph output.  Optionally, all capabilities can be prefixed with '-' to specify capabilities to ignore.")
 	buildTags      = flag.String("buildtags", "", "command-separated list of build tags to use when loading packages")
 	goos           = flag.String("goos", "", "GOOS value to use when loading packages")
 	goarch         = flag.String("goarch", "", "GOARCH value to use when loading packages")
@@ -116,6 +117,7 @@ func run() error {
 		Classifier:     classifier,
 		DisableBuiltin: *disableBuiltin,
 		Granularity:    *granularity,
+		Capabilities:   *capabilities,
 	})
 
 	if *memprofile != "" {


### PR DESCRIPTION
Setting -capabilities to e.g. "NETWORK" or "-UNSAFE" will specify capabilities to include or exclude from the output graph.

Adds a parameter to analyzer.CapabilityGraph to do this filtering.