### PR TITLE
go.mod: depend on a newer commit of x/tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/fatih/color v1.17.0
 	github.com/google/go-cmp v0.6.0
-	golang.org/x/tools v0.22.0
+	golang.org/x/tools v0.22.1-0.20240611174316-dddd55df4919
 	google.golang.org/protobuf v1.34.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -17,5 +17,7 @@ golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
 golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
+golang.org/x/tools v0.22.1-0.20240611174316-dddd55df4919 h1:1w8+AGdClrtGcGjAyeL0oj7O/e9qc8mXzU3hatDsD9M=
+golang.org/x/tools v0.22.1-0.20240611174316-dddd55df4919/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=


### PR DESCRIPTION
This commit includes some bug fixes relevant to Capslock.