### PR TITLE
analyzer: fix DOT output for empty graphs

### DIFF
--- a/analyzer/graph.go
+++ b/analyzer/graph.go
@@ -89,24 +89,21 @@ func graphOutput(pkgs []*packages.Package, queriedPackages map[*types.Package]st
 type graphBuilder struct {
 	io.Writer
 	nodeNamer func(any) string
-	started   bool
 	done      bool
 }
 
 func newGraphBuilder(w io.Writer, nodeNamer func(any) string) graphBuilder {
-	return graphBuilder{
+	gb := graphBuilder{
 		Writer:    w,
 		nodeNamer: nodeNamer,
 	}
+	gb.Write([]byte("digraph {\n"))
+	return gb
 }
 
 func (gb *graphBuilder) Edge(from, to interface{}) {
 	if gb.done {
 		panic("done")
-	}
-	if !gb.started {
-		gb.Write([]byte("digraph {\n"))
-		gb.started = true
 	}
 	gb.Write([]byte("\t"))
 	gb.Write([]byte(`"`))

--- a/testing/analyzepackages_test.go
+++ b/testing/analyzepackages_test.go
@@ -311,6 +311,13 @@ func TestGraph(t *testing.T) {
 				`}`: 0,
 			},
 		},
+		{
+			[]string{"-packages=../testpkgs/callutf8", "-output=graph"},
+			map[string]int{
+				`digraph {`: 0,
+				`}`:         0,
+			},
+		},
 	} {
 		cmd := exec.Command(bin, test.args...)
 		var output bytes.Buffer


### PR DESCRIPTION
Previously, an empty graph would be written as just "}".