### PR TITLE
go.mod: upgrade Go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/capslock
 
-go 1.20
+go 1.21
 
 require (
 	github.com/fatih/color v1.17.0


### PR DESCRIPTION
Use the new maps and slices packages to simplify the classifier merging code.