### PR TITLE
analyzer: make exported types Granularity and CapabilitySet

### DIFF
--- a/analyzer/analyzer.go
+++ b/analyzer/analyzer.go
@@ -27,15 +27,12 @@ type Config struct {
 	// DisableBuiltin disables some additional source-code analyses that find
 	// more capabilities in functions.
 	DisableBuiltin bool
-	// Granularity can be "package" or "function".  It determines whether
-	// capability sets are examined per-package or per-function when doing
-	// comparisons.
-	Granularity string
-	// Capabilities is a comma-separated list of capabilities to use for graph
-	// output mode.  Optionally, the capabilities can all be prefixed with a '-'
-	// character to indicate capabilities to omit.
-	// If the string is empty, all capabilities are used.
-	Capabilities string
+	// Granularity determines whether capability sets are examined per-package
+	// or per-function when doing comparisons.
+	Granularity Granularity
+	// CapabilitySet is the set of capabilities to use for graph output mode.
+	// If CapabilitySet is nil, all capabilities are used.
+	CapabilitySet *CapabilitySet
 }
 
 // Classifier is an interface for types that help map code features to

--- a/analyzer/analyzer_test.go
+++ b/analyzer/analyzer_test.go
@@ -294,7 +294,7 @@ func TestGraphWithClassifier(t *testing.T) {
 	}
 }
 
-func TestParseCapabilitiesList(t *testing.T) {
+func TestNewCapabilitySet(t *testing.T) {
 	for _, test := range []struct {
 		list             string
 		wantCapabilities map[cpb.Capability]struct{}
@@ -362,19 +362,25 @@ func TestParseCapabilitiesList(t *testing.T) {
 			wantNegated: false,
 		},
 	} {
-		capabilities, negated, err := parseCapabilitiesList(test.list)
+		cs, err := NewCapabilitySet(test.list)
 		if err != nil {
-			t.Errorf("parseCapabilitiesList(%q): got err == %v, want nil error",
+			t.Errorf("NewCapabilitySet(%q): got err == %v, want nil error",
 				test.list, err)
 			continue
 		}
-		if !reflect.DeepEqual(capabilities, test.wantCapabilities) {
-			t.Errorf("parseCapabilitiesList(%q): got capabilities %v want %v",
-				test.list, capabilities, test.wantCapabilities)
+		if test.wantCapabilities == nil {
+			if cs != nil {
+				t.Errorf("NewCapabilitySet(%q): got non-nil, want nil", test.list)
+			}
+			continue
 		}
-		if negated != test.wantNegated {
-			t.Errorf("parseCapabilitiesList(%q): got negated = %v want %v",
-				test.list, negated, test.wantNegated)
+		if !reflect.DeepEqual(cs.capabilities, test.wantCapabilities) {
+			t.Errorf("NewCapabilitySet(%q): got capabilities %v want %v",
+				test.list, cs.capabilities, test.wantCapabilities)
+		}
+		if cs.negated != test.wantNegated {
+			t.Errorf("NewCapabilitySet(%q): got negated = %v want %v",
+				test.list, cs.negated, test.wantNegated)
 		}
 	}
 	for _, list := range []string{
@@ -390,9 +396,9 @@ func TestParseCapabilitiesList(t *testing.T) {
 		",,",
 		"\x00",
 	} {
-		_, _, err := parseCapabilitiesList(list)
+		_, err := NewCapabilitySet(list)
 		if err == nil {
-			t.Errorf("parseCapabilitiesList(%q): got err == nil, want error", list)
+			t.Errorf("NewCapabilitySet(%q): got err == nil, want error", list)
 		}
 	}
 }

--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -39,7 +39,7 @@ var (
 	goarch         = flag.String("goarch", "", "GOARCH value to use when loading packages")
 	cpuprofile     = flag.String("cpuprofile", "", "write cpu profile to specified file")
 	memprofile     = flag.String("memprofile", "", "write memory profile to specified file")
-	granularity    = flag.String("granularity", "package",
+	granularity    = flag.String("granularity", "",
 		`the granularity to use for comparisons, either "package" or "function".`)
 )
 
@@ -70,6 +70,14 @@ func run() error {
 	}
 
 	packageNames := strings.Split(*packageList, ",")
+	g, err := analyzer.GranularityFromString(*granularity)
+	if err != nil {
+		return fmt.Errorf("parsing flag -granularity: %w", err)
+	}
+	cs, err := analyzer.NewCapabilitySet(*capabilities)
+	if err != nil {
+		return fmt.Errorf("parsing flag -capabilities: %w", err)
+	}
 	if *disableBuiltin && *customMap == "" {
 		return fmt.Errorf("Error: --disable_builtin only makes sense with a --capability_map file specified")
 	}
@@ -116,8 +124,8 @@ func run() error {
 	err = analyzer.RunCapslock(flag.Args(), *output, pkgs, queriedPackages, &analyzer.Config{
 		Classifier:     classifier,
 		DisableBuiltin: *disableBuiltin,
-		Granularity:    *granularity,
-		Capabilities:   *capabilities,
+		Granularity:    g,
+		CapabilitySet:  cs,
 	})
 
 	if *memprofile != "" {


### PR DESCRIPTION
Adds GranularityFromString and NewCapabilitySet functions for creating
these from command-line flags or other strings.

This simplifies the code, and allows callers of the library to validate
strings before calling more expensive setup functions.

We allow "" as a valid granularity, to indicate the default granularity
for the operation.