### PR TITLE
analyzer: add option to omit example call paths

### DIFF
--- a/analyzer/static/verbose.tmpl
+++ b/analyzer/static/verbose.tmpl
@@ -6,6 +6,6 @@ Share feedback and file bugs at {{format "highlight"}}https://github.com/google/
 {{range $val := .ModuleInfo}}  {{$val.Path}} {{$val.Version}}
 {{end}}{{end}}{{if .CapabilityStats}}{{range $index, $p := .CapabilityStats}}
 {{format "capability" $p.Capability}}{{$p.Capability}}{{format}}: {{$p.Count}} references ({{$p.DirectCount}} direct, {{$p.TransitiveCount}} transitive)
-Example callpath:
+Example {{if eq (len $p.ExampleCallpath) 1}}function{{else}}callpath{{end}}:
 {{range $val := $p.ExampleCallpath}}  {{format "callpath-site"}}{{if $val.Site}}{{$val.Site.Filename}}:{{$val.Site.Line}}:{{$val.Site.Column}}:{{end}}{{format "callpath"}}{{$val.Name}}{{format}}
 {{end}}{{end}}{{else}}{{format "nocap"}}Capslock found no capabilities in this package.{{format}}{{end}}

--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -44,6 +44,7 @@ var (
 	granularity    = flag.String("granularity", "",
 		`the granularity to use for comparisons, either "package" or "function".`)
 	forceLocalModule = flag.Bool("force_local_module", false, "if the requested packages cannot be loaded in the current workspace, return an error immediately, instead of trying to load them in a temporary module")
+	omitPaths        = flag.Bool("omit_paths", false, "omit example call paths from output")
 )
 
 func main() {
@@ -174,6 +175,7 @@ func run() error {
 		DisableBuiltin: *disableBuiltin,
 		Granularity:    g,
 		CapabilitySet:  cs,
+		OmitPaths:      *omitPaths,
 	})
 
 	if *memprofile != "" {


### PR DESCRIPTION
The example call paths can use a lot of space.  This change adds an option to omit them.

In the json output, when granularity=function, the function is still included as the first element of the path.