### PR TITLE
correct the install instructions to use capslock-git-diff

### DIFF
--- a/cmd/capslock-git-diff/main.go
+++ b/cmd/capslock-git-diff/main.go
@@ -13,7 +13,7 @@
 //
 // This requires Capslock to be installed:
 //
-//	go install github.com/google/capslock/cmd/capslock@latest
+//	go install github.com/google/capslock/cmd/capslock-git-diff@latest
 //
 // To compare against the current state of the repository, specify "." as a
 // revision:


### PR DESCRIPTION
The instructions for installing `capslock-git-diff` are incorrect in the cmd file.