### PR TITLE
cmd/capslock: add -version flag

### DIFF
--- a/testing/analyzepackages_test.go
+++ b/testing/analyzepackages_test.go
@@ -463,3 +463,13 @@ func TestCompare(t *testing.T) {
 		}
 	}
 }
+
+func TestVersionFlag(t *testing.T) {
+	out, err := exec.Command(bin, "-version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("running capslock: error %v output %q", err, string(out))
+	}
+	if s, want := string(out), "capslock version"; !strings.HasPrefix(s, want) {
+		t.Errorf("got %q, want prefix %q", s, want)
+	}
+}


### PR DESCRIPTION
Outputs version numbers of the code that most affects the analysis.

It uses the build information embedded in the executable to print the version of capslock, the version of the Go toolchain, and the version of the golang.org/x/tools module used.

Fixes #267