### PR TITLE
cmd/capslock: add package output format

### DIFF
--- a/cmd/capslock/capslock.go
+++ b/cmd/capslock/capslock.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	packageList    = flag.String("packages", "", "target patterns to be analysed; allows wildcarding")
-	output         = flag.String("output", "", "output mode to use; non-default options are json, m, v, graph, and compare")
+	output         = flag.String("output", "", "output mode to use; non-default options are json, m, package, v, graph, and compare")
 	verbose        = flag.Int("v", 0, "verbosity level")
 	noiseFlag      = flag.Bool("noisy", false, "include output on unanalyzed function calls (can be noisy)")
 	customMap      = flag.String("capability_map", "", "use a custom capability map file")


### PR DESCRIPTION
Fixes #266.

This PR adds a `package` output format which produces human-readable JSON of each packages capabilities, for example:

    capslock -output package

produces output like:

```json
{
  "filippo.io/age": [
    "CAPABILITY_MODIFY_SYSTEM_STATE",
    "CAPABILITY_OPERATING_SYSTEM",
    "CAPABILITY_RUNTIME"
  ],
  "filippo.io/age/agessh": [
    "CAPABILITY_MODIFY_SYSTEM_STATE"
  ],
  "github.com/bodgit/sevenzip": [
    "CAPABILITY_CGO",
    "CAPABILITY_EXEC",
    "CAPABILITY_MODIFY_SYSTEM_STATE"
  ],
  "github.com/charmbracelet/bubbletea": [
    "CAPABILITY_MODIFY_SYSTEM_STATE"
  ],
  "github.com/dsnet/compress/bzip2": [
    "CAPABILITY_UNANALYZED"
  ],
  "github.com/dsnet/compress/internal/prefix": [
    "CAPABILITY_UNANALYZED"
  ]
}
```